### PR TITLE
Allow skip validation at a higher level

### DIFF
--- a/urbanopt_des/urbanopt_analysis.py
+++ b/urbanopt_des/urbanopt_analysis.py
@@ -34,7 +34,7 @@ class URBANoptAnalysis:
         """
         self.geojson_file = geojson_file
         if geojson_file.exists():
-            self.geojson = DESGeoJSON(geojson_file)
+            self.geojson = DESGeoJSON(geojson_file, **kwargs)
         else:
             raise Exception(f"GeoJSON file does not exist: {geojson_file}")
 


### PR DESCRIPTION
For the DESGeoJSON file, there can be cases where we need to skip validation when creating the URBANoptAnalysis object. For example:

```
uo_analysis = URBANoptAnalysis(geojson_file=pre_uo_geojson_file, analysis_dir=Path.cwd(), skip_validation=True)
```

This is a simple change that passes the kwargs to the next object.