### PR TITLE
Fail loudly on uo install_python errors and target URBANopt CLI 1.3.0

### DIFF
--- a/tests/test_uo_cli_wrapper.py
+++ b/tests/test_uo_cli_wrapper.py
@@ -4,6 +4,7 @@
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -302,6 +303,53 @@ class TestUOCliWrapper(unittest.TestCase):
             run_cmd.assert_not_called()
         finally:
             UOCliWrapper._python_bootstrap_attempted = previous_bootstrap_attempted
+
+    def test_install_python_raises_on_missing_distribution(self):
+        """install_python fails loudly when a dependency cannot be installed."""
+        wrapper = UOCliWrapper(self.temp_path, "test_project", Path(__file__).parent, auto_initialize_python=False)
+        failed = subprocess.CompletedProcess(
+            args="uo install_python",
+            returncode=0,  # uo install_python swallows pip failures and still exits 0
+            stdout=b"Installing NREL-disco 0.5.1\nERROR: No matching distribution found for dsspy==3.0.2\n",
+            stderr=b"",
+        )
+        with (
+            mock.patch.object(wrapper, "_run_command", return_value=failed) as run_cmd,
+            pytest.raises(RuntimeError, match="failed to install"),
+        ):
+            wrapper.install_python()
+
+        run_cmd.assert_called_once_with("uo install_python")
+
+    def test_install_python_raises_on_nonzero_exit(self):
+        """install_python fails loudly when the command itself exits non-zero."""
+        wrapper = UOCliWrapper(self.temp_path, "test_project", Path(__file__).parent, auto_initialize_python=False)
+        failed = subprocess.CompletedProcess(
+            args="uo install_python",
+            returncode=1,
+            stdout=b"",
+            stderr=b"boom",
+        )
+        with mock.patch.object(wrapper, "_run_command", return_value=failed), pytest.raises(RuntimeError, match="status 1"):
+            wrapper.install_python()
+
+    def test_install_python_ignores_benign_dependency_conflict_warning(self):
+        """install_python does not raise on success or benign pip resolver warnings."""
+        wrapper = UOCliWrapper(self.temp_path, "test_project", Path(__file__).parent, auto_initialize_python=False)
+        ok = subprocess.CompletedProcess(
+            args="uo install_python",
+            returncode=0,
+            stdout=(
+                b"Installing ThermalNetwork 0.5.0\n"
+                b"ERROR: pip's dependency resolver does not currently take into account all the "
+                b"packages that are installed.\n"
+                b"ghedesigner 2.1.1 requires click>=8.3.1, but you have click 8.1.8 which is incompatible.\n"
+                b"Done\n"
+            ),
+            stderr=b"",
+        )
+        with mock.patch.object(wrapper, "_run_command", return_value=ok):
+            wrapper.install_python()  # should not raise
 
     def test_des_create_command(self):
         """Test des_create executes uo des_create command."""

--- a/urbanopt_des/uo_cli_wrapper.py
+++ b/urbanopt_des/uo_cli_wrapper.py
@@ -18,9 +18,18 @@ class UOCliWrapper:
         . ~/.env_uo.sh
     """
 
-    DEFAULT_UO_VERSION = "1.2.0"
+    DEFAULT_UO_VERSION = "1.3.0"
 
     _python_bootstrap_attempted = False
+
+    # Substrings emitted by pip (via `uo install_python`) when a dependency cannot
+    # be installed at all. `uo install_python` logs these and still exits 0, so we
+    # scan its output for them to fail loudly instead of continuing with a broken
+    # Python environment.
+    _PIP_INSTALL_FAILURE_MARKERS = (
+        "No matching distribution found",
+        "Could not find a version that satisfies the requirement",
+    )
 
     def __init__(self, working_dir: Path, uo_project: str, template_dir: Path, auto_initialize_python=True):
         """uo_project is the name of the project which is also the project folder
@@ -134,6 +143,7 @@ class UOCliWrapper:
                 log.write(result.stderr.decode("utf-8"))
                 print(result.stdout.decode("utf-8"))
                 print(result.stderr.decode("utf-8"))
+            return result
         finally:
             os.chdir(current_dir)
 
@@ -179,8 +189,34 @@ class UOCliWrapper:
         self._run_command(f"uo create -s {scoped_feature_path}")
 
     def install_python(self):
-        """Run uo install_python."""
-        self._run_command("uo install_python")
+        """Run ``uo install_python`` and fail loudly if any dependency cannot install.
+
+        ``uo install_python`` exits 0 even when individual Python package installs
+        fail: it logs the error and keeps going. That leaves the URBANopt CLI's
+        Python environment incomplete and later surfaces as confusing, seemingly
+        unrelated errors (e.g. degraded system-parameter values). Scan the command
+        output for the unambiguous pip failure markers and raise so the real cause
+        is obvious.
+
+        Raises:
+            RuntimeError: If a dependency failed to install or the command exited
+                with a non-zero status.
+        """
+        result = self._run_command("uo install_python")
+
+        output = ""
+        if result is not None:
+            output = f"{result.stdout.decode('utf-8', 'replace')}{result.stderr.decode('utf-8', 'replace')}"
+
+        failures = [marker for marker in self._PIP_INSTALL_FAILURE_MARKERS if marker in output]
+        if result is not None and result.returncode != 0:
+            failures.append(f"command exited with status {result.returncode}")
+
+        if failures:
+            raise RuntimeError(
+                "uo install_python failed to install one or more Python dependencies "
+                f"({'; '.join(failures)}). See the log at {self.log_file} for details."
+            )
 
     def create_project_at_path(self, project_path, create_flags=None):
         """Run uo create -p for an explicit project path.


### PR DESCRIPTION
## Why

The `test_uo_cli_from_scratch_integration_test` integration tests failed in CI ([run](https://github.com/urbanopt/urbanopt-des/actions/runs/29437934730/job/87429182603?pr=88)) with a misleading assertion error on `ets_pump_flow_rate > 0.0005`. The real root cause was upstream: `uo install_python` (via URBANopt CLI 1.2.0) failed to install `NREL-disco==0.5.1` because its transitive dependency `dsspy==3.0.2` was removed from PyPI (404). `uo install_python` logs the pip error but still exits 0, so the test continued with a broken CLI Python environment and produced degraded system-parameter values — surfacing far from the actual failure.

The same test passed on `develop` ~2 hours earlier; only the upstream package availability changed.

## What

- **Fail loudly:** `install_python()` now inspects the command output and exit code and raises `RuntimeError` when a dependency can't be installed (`No matching distribution found` / `Could not find a version that satisfies the requirement`) or the command exits non-zero. It ignores the benign `pip's dependency resolver does not currently take into account…` conflict warning so it won't false-positive. `_run_command` now returns the `CompletedProcess` so callers can inspect it.
- **Bump the dependency:** `DEFAULT_UO_VERSION` `1.2.0` → `1.3.0`. CLI 1.3.0 installs `NREL-disco==0.6.0`, which drops the yanked `dsspy==3.0.2` dependency. Verified v1.3.0 ships the `NREL-disco==0.6.0` python deps and the `Ubuntu-22.04-x86_64.deb` asset that CI downloads.

## Tests

Added three unit tests for `install_python`: raises on a missing distribution, raises on non-zero exit, and does not raise on a benign pip resolver conflict warning.

Verified locally: unit tests (33) pass, `mypy` clean, `ruff-check` + `ruff-format` pass.

Note: the `_bootstrap_python_if_needed` path remains best-effort (it calls `_run_command` directly, by design) — only the explicit `install_python()` entry point fails loudly.